### PR TITLE
Support decimal pack versions

### DIFF
--- a/src/main/kotlin/gg/meza/stonecraft/HelperFunctions.kt
+++ b/src/main/kotlin/gg/meza/stonecraft/HelperFunctions.kt
@@ -1,29 +1,80 @@
 package gg.meza.stonecraft
 
-import com.google.gson.GsonBuilder
-import com.google.gson.reflect.TypeToken
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import org.gradle.api.Project
 import java.io.InputStreamReader
+import java.math.BigDecimal
+import java.math.BigInteger
+
+@JvmInline
+value class PackFormatVersion private constructor(private val value: BigDecimal) : Comparable<PackFormatVersion> {
+    companion object {
+        fun of(value: BigDecimal): PackFormatVersion = PackFormatVersion(value.stripTrailingZeros())
+        fun of(number: Number): PackFormatVersion = when (number) {
+            is BigDecimal -> of(number)
+            is BigInteger -> of(number.toBigDecimal())
+            is Long -> of(BigDecimal.valueOf(number))
+            is Int -> of(BigDecimal.valueOf(number.toLong()))
+            is Short -> of(BigDecimal.valueOf(number.toLong()))
+            is Byte -> of(BigDecimal.valueOf(number.toLong()))
+            is Double -> of(BigDecimal.valueOf(number))
+            is Float -> of(BigDecimal.valueOf(number.toDouble()))
+            else -> of(BigDecimal(number.toString()))
+        }
+    }
+
+    fun toIntExact(): Int = try {
+        value.intValueExact()
+    } catch (ex: ArithmeticException) {
+        throw IllegalStateException("Pack format $value cannot be represented as an Int", ex)
+    }
+
+    fun toBigDecimal(): BigDecimal = value
+
+    fun toDouble(): Double = value.toDouble()
+
+    fun isWholeNumber(): Boolean = runCatching { value.intValueExact() }.isSuccess
+
+    override fun compareTo(other: PackFormatVersion): Int = value.compareTo(other.value)
+
+    operator fun compareTo(other: Int): Int = value.compareTo(BigDecimal.valueOf(other.toLong()))
+
+    override fun toString(): String = value.stripTrailingZeros().toPlainString()
+}
 
 fun String.upperCaseFirst() = replaceFirstChar { if (it.isLowerCase()) it.uppercaseChar() else it }
-private data class PackFormats(val datapack: Int, val resourcepack: Int)
+private data class PackFormats(val datapack: PackFormatVersion, val resourcepack: PackFormatVersion)
 
 private object ResourceHolder
 
-private val resourceVersionMap: Map<String, Int> by lazy {
+private val packFormatMap: Map<String, PackFormats> by lazy {
     val stream = requireNotNull(
         ResourceHolder::class.java.classLoader.getResourceAsStream("pack_versions.json")
     ) { "pack_versions.json not found" }
-    val type = object : TypeToken<Map<String, PackFormats>>() {}.type
-    val map: Map<String, PackFormats> =
-        GsonBuilder().create().fromJson(InputStreamReader(stream), type)
-    map.mapValues { it.value.resourcepack }
+    val json = JsonParser.parseReader(InputStreamReader(stream)).asJsonObject
+    json.entrySet().associate { (version, data) ->
+        version to data.asJsonObject.toPackFormats()
+    }
 }
 
-fun getResourceVersionFor(version: String): Int {
-    return resourceVersionMap[version]
+private fun JsonObject.toPackFormats(): PackFormats {
+    return PackFormats(
+        PackFormatVersion.of(get("datapack").asBigDecimal),
+        PackFormatVersion.of(get("resourcepack").asBigDecimal)
+    )
+}
+
+private fun getPackFormats(version: String): PackFormats {
+    return packFormatMap[version]
         ?: throw IllegalArgumentException("Unknown Minecraft version: $version")
 }
+
+fun getResourcePackFormat(version: String): PackFormatVersion = getPackFormats(version).resourcepack
+
+fun getDatapackFormat(version: String): PackFormatVersion = getPackFormats(version).datapack
+
+fun getResourceVersionFor(version: String): Int = getResourcePackFormat(version).toIntExact()
 
 fun getProgramArgs(vararg lists: List<String>): List<String> = lists.flatMap { it }
 

--- a/src/main/kotlin/gg/meza/stonecraft/configurations/ProcessResources.kt
+++ b/src/main/kotlin/gg/meza/stonecraft/configurations/ProcessResources.kt
@@ -1,7 +1,7 @@
 package gg.meza.stonecraft.configurations
 
 import gg.meza.stonecraft.extension.ModSettingsExtension
-import gg.meza.stonecraft.getResourceVersionFor
+import gg.meza.stonecraft.getResourcePackFormat
 import gg.meza.stonecraft.mod
 import gg.meza.stonecraft.tasks.McMetaCreation
 import org.gradle.api.Project
@@ -17,7 +17,7 @@ fun configureProcessResources(project: Project, minecraftVersion: String, modSet
      */
     if (project.mod.isForge) {
         project.tasks.register<McMetaCreation>("generatePackMCMetaJson") {
-            resourcePackVersion.set(getResourceVersionFor(minecraftVersion))
+            resourcePackVersion.set(getResourcePackFormat(minecraftVersion).toBigDecimal())
         }
     }
 
@@ -41,13 +41,13 @@ fun configureProcessResources(project: Project, minecraftVersion: String, modSet
         // Deal with the general resources
         project.project.tasks.withType<ProcessResources> {
             duplicatesStrategy = DuplicatesStrategy.INCLUDE
-            val currentResourceVersion = getResourceVersionFor(minecraftVersion)
+            val currentResourceVersion = getResourcePackFormat(minecraftVersion)
 
             // Version 43 changed how the resource directories are named
             val needsOldResources = currentResourceVersion < 34
 
             doFirst {
-                logger.debug(String.format("Current resource version is %d", currentResourceVersion))
+                logger.debug(String.format("Current resource version is %s", currentResourceVersion.toString()))
             }
 
             val basicModDetails = mapOf(
@@ -57,7 +57,7 @@ fun configureProcessResources(project: Project, minecraftVersion: String, modSet
                 "description" to project.mod.description,
                 "version" to project.mod.version,
                 "minecraftVersion" to minecraftVersion,
-                "packVersion" to getResourceVersionFor(minecraftVersion),
+                "packVersion" to currentResourceVersion.toBigDecimal(),
                 "fabricVersion" to project.mod.prop("fabric_version", "not set"),
                 "forgeVersion" to project.mod.prop("forge_version", "not set"),
                 "neoforgeVersion" to project.mod.prop("neoforge_version", "not set"),

--- a/src/main/kotlin/gg/meza/stonecraft/tasks/McMetaCreation.kt
+++ b/src/main/kotlin/gg/meza/stonecraft/tasks/McMetaCreation.kt
@@ -6,6 +6,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.math.BigDecimal
 import java.nio.file.Files
 
 data class PackMeta(
@@ -13,13 +14,13 @@ data class PackMeta(
 )
 
 data class Pack(
-    val pack_format: Int,
+    val pack_format: BigDecimal,
     val description: String,
     val supported_formats: SupportedFormat? = null
 )
 
 data class SupportedFormat(
-    val min_inclusive: Int
+    val min_inclusive: BigDecimal
 )
 
 abstract class McMetaCreation : DefaultTask() {
@@ -43,7 +44,7 @@ abstract class McMetaCreation : DefaultTask() {
      * The resource pack version to use in the pack.mcmeta file
      */
     @Input
-    val resourcePackVersion = project.objects.property(Int::class.java)
+    val resourcePackVersion = project.objects.property(BigDecimal::class.java)
 
     init {
         group = "mod"
@@ -52,8 +53,8 @@ abstract class McMetaCreation : DefaultTask() {
 
     @TaskAction
     fun generateMcMeta() {
-        val version = requireNotNull(resourcePackVersion.get()) { "Resource pack version must be set with `resourcePackVersion`" }
-        val newFormat = version >= 18
+        val version = requireNotNull(resourcePackVersion.orNull) { "Resource pack version must be set with `resourcePackVersion`" }
+        val newFormat = version >= BigDecimal.valueOf(18L)
 
         if (inputPackFile.exists()) {
             logger.lifecycle("Pack file exists, there's no need to generate one.")

--- a/src/test/kotlin/gg/meza/stonecraft/HelperFunctionsTest.kt
+++ b/src/test/kotlin/gg/meza/stonecraft/HelperFunctionsTest.kt
@@ -1,8 +1,10 @@
 package gg.meza.stonecraft
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 
 class HelperFunctionsTest {
     @Test
@@ -16,5 +18,28 @@ class HelperFunctionsTest {
     @Test
     fun `throws for unknown versions`() {
         assertThrows(IllegalArgumentException::class.java) { getResourceVersionFor("0.20.1") }
+    }
+
+    @Test
+    fun `exposes decimal resource pack formats`() {
+        val packFormat = getResourcePackFormat("25w33a")
+
+        assertEquals(BigDecimal("65.2"), packFormat.toBigDecimal())
+        assertFalse(packFormat.isWholeNumber())
+    }
+
+    @Test
+    fun `exposes decimal datapack formats`() {
+        val datapackFormat = getDatapackFormat("25w33a")
+
+        assertEquals(BigDecimal("83.1"), datapackFormat.toBigDecimal())
+        assertFalse(datapackFormat.isWholeNumber())
+    }
+
+    @Test
+    fun `integral accessor fails for decimal pack formats`() {
+        assertThrows(IllegalStateException::class.java) {
+            getResourceVersionFor("25w33a")
+        }
     }
 }

--- a/src/test/kotlin/gg/meza/stonecraft/tasks/McMetaCreationTest.kt
+++ b/src/test/kotlin/gg/meza/stonecraft/tasks/McMetaCreationTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.math.BigDecimal
 import java.util.UUID
 
 @DisplayName("Test pack mcmeta generation for forge")
@@ -43,7 +44,7 @@ class McMetaCreationTest : IntegrationTest {
     @Test
     fun `packfile can be generated for old versions`() {
         val mcMetaCreation = project.tasks.register<McMetaCreation>("mcMetaCreation") {
-            resourcePackVersion.set(6)
+            resourcePackVersion.set(BigDecimal.valueOf(6L))
         }.get()
 
         mcMetaCreation.generateMcMeta()
@@ -55,7 +56,7 @@ class McMetaCreationTest : IntegrationTest {
          */
         val expectedContent = PackMeta(
             Pack(
-                pack_format = 6,
+                pack_format = BigDecimal.valueOf(6L),
                 description = description
             )
         )
@@ -69,7 +70,7 @@ class McMetaCreationTest : IntegrationTest {
     @Test
     fun `packfile correctly generates for the first version supporting the new format`() {
         val mcMetaCreation = project.tasks.register<McMetaCreation>("mcMetaCreation") {
-            resourcePackVersion.set(18)
+            resourcePackVersion.set(BigDecimal.valueOf(18L))
         }.get()
 
         mcMetaCreation.generateMcMeta()
@@ -81,9 +82,9 @@ class McMetaCreationTest : IntegrationTest {
          */
         val expectedContent = PackMeta(
             Pack(
-                pack_format = 18,
+                pack_format = BigDecimal.valueOf(18L),
                 description = description,
-                supported_formats = SupportedFormat(18)
+                supported_formats = SupportedFormat(BigDecimal.valueOf(18L))
             )
         )
 
@@ -96,7 +97,7 @@ class McMetaCreationTest : IntegrationTest {
     @Test
     fun `packfile correctly generates for the new versions`() {
         val mcMetaCreation = project.tasks.register<McMetaCreation>("mcMetaCreation") {
-            resourcePackVersion.set(21)
+            resourcePackVersion.set(BigDecimal.valueOf(21L))
         }.get()
 
         mcMetaCreation.generateMcMeta()
@@ -108,9 +109,9 @@ class McMetaCreationTest : IntegrationTest {
          */
         val expectedContent = PackMeta(
             Pack(
-                pack_format = 21,
+                pack_format = BigDecimal.valueOf(21L),
                 description = description,
-                supported_formats = SupportedFormat(21)
+                supported_formats = SupportedFormat(BigDecimal.valueOf(21L))
             )
         )
 
@@ -127,7 +128,7 @@ class McMetaCreationTest : IntegrationTest {
         inputFile.writeText(packFileContents)
 
         val mcMetaCreation = project.tasks.register<McMetaCreation>("mcMetaCreation") {
-            resourcePackVersion.set(21)
+            resourcePackVersion.set(BigDecimal.valueOf(21L))
         }.get()
 
         mcMetaCreation.generateMcMeta()


### PR DESCRIPTION
## Summary
- add a PackFormatVersion wrapper so datapack and resource pack versions can carry decimal formats
- update process resources and mcmeta generation to work with BigDecimal pack versions end-to-end
- extend helper and task tests to cover decimal pack format handling alongside the legacy integer paths

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e12491a844832fbcf6b0c2598b7ef6