### PR TITLE
docs: multi-version AW setup

### DIFF
--- a/docs/docs/06-access-widening.md
+++ b/docs/docs/06-access-widening.md
@@ -74,12 +74,12 @@ modSettings {
         ...
     }
 
-    variableReplacements.set(mapOf("aw_file", accesswidener));
+    variableReplacements.set(mapOf("aw_file", accesswidener))
 
 }
 ```
 
-This will use the previously assigned value of `accesswidener` as the `aw_file` variable. We have previously set it up in our `fabric.mod.json` above ([Using string templates](#using-string-template)).
+This will use the previously assigned value of `accesswidener` as the `aw_file` variable. We have previously set it up in our `fabric.mod.json` above ([Using string template](#using-string-template)).
 
 Building the project should run the necessary tasks in order to apply your access widening.
 
@@ -125,7 +125,7 @@ val accesstransformer = when {
 
 minecraft {
     accessTransformers {
-        file("../../src/main/resources/accesstransformers/$accesstransformer")
+        file(rootProject.file("src/main/resources/accesstransformers/$accesstransformer")
     }
 }
 ```
@@ -148,10 +148,10 @@ modSettings {
         ...
     }
 
-    variableReplacements.set(mapOf("at_file", accesstransformer));
+    variableReplacements.set(mapOf("at_file", accesstransformer))
 }
 ```
 
-This will use the previously assigned value of `accesstransformer` as the `at_file` variable. We have previously set it up in our `neoforge.mods.toml` above ([Using string templates](#using-string-template)).
+This will use the previously assigned value of `accesstransformer` as the `at_file` variable. We have previously set it up in our `neoforge.mods.toml` above ([Using string template](#using-string-template)).
 
 Building the project should run the necessary tasks in order to apply your access widening.


### PR DESCRIPTION
Added docs for setting up AW for both Fabric and (Neo)Forge.
The main difference with Stonecutter docs lies in using `variableReplacements`, but a complete explanation has been provided for future reference.

<details><summary>Page preview</summary>
<img width="1591" height="5010" alt="preview" src="https://github.com/user-attachments/assets/1aea948c-150e-487c-8e65-544cc77bc5f5" />
</details> 