### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-2

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1754,5 +1754,9 @@
   "26.1-snapshot-1": {
     "datapack": 95,
     "resourcepack": 76
+  },
+  "26.1-snapshot-2": {
+    "datapack": 96,
+    "resourcepack": 77
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-2.