### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-4

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1762,5 +1762,9 @@
   "26.1-snapshot-3": {
     "datapack": 97,
     "resourcepack": 78
+  },
+  "26.1-snapshot-4": {
+    "datapack": 97.1,
+    "resourcepack": 78.1
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-4.