### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-5

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1766,5 +1766,9 @@
   "26.1-snapshot-4": {
     "datapack": 97.1,
     "resourcepack": 78.1
+  },
+  "26.1-snapshot-5": {
+    "datapack": 98,
+    "resourcepack": 79
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-5.