### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-6

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1770,5 +1770,9 @@
   "26.1-snapshot-5": {
     "datapack": 98,
     "resourcepack": 79
+  },
+  "26.1-snapshot-6": {
+    "datapack": 99,
+    "resourcepack": 80
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-6.