### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-7

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1774,5 +1774,9 @@
   "26.1-snapshot-6": {
     "datapack": 99,
     "resourcepack": 80
+  },
+  "26.1-snapshot-7": {
+    "datapack": 99.1,
+    "resourcepack": 81
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-7.