### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-8

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1778,5 +1778,9 @@
   "26.1-snapshot-7": {
     "datapack": 99.1,
     "resourcepack": 81
+  },
+  "26.1-snapshot-8": {
+    "datapack": 99.2,
+    "resourcepack": 81.1
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-8.