### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-9

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1782,5 +1782,9 @@
   "26.1-snapshot-8": {
     "datapack": 99.2,
     "resourcepack": 81.1
+  },
+  "26.1-snapshot-9": {
+    "datapack": 99.2,
+    "resourcepack": 81.1
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-9.