### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-10

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1786,5 +1786,9 @@
   "26.1-snapshot-9": {
     "datapack": 99.2,
     "resourcepack": 81.1
+  },
+  "26.1-snapshot-10": {
+    "datapack": 99.3,
+    "resourcepack": 82
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-10.