### PR TITLE
fix(pack-format): update pack-format map for 26.1-snapshot-11

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1790,5 +1790,9 @@
   "26.1-snapshot-10": {
     "datapack": 99.3,
     "resourcepack": 82
+  },
+  "26.1-snapshot-11": {
+    "datapack": 100,
+    "resourcepack": 83
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-snapshot-11.