### PR TITLE
fix(pack-format): update pack-format map for 26.1-pre-1

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1794,5 +1794,9 @@
   "26.1-snapshot-11": {
     "datapack": 100,
     "resourcepack": 83
+  },
+  "26.1-pre-1": {
+    "datapack": 101,
+    "resourcepack": 84
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.1-pre-1.