### PR TITLE
fix(pack-format): update pack-format map for 26.2-snapshot-2

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1846,5 +1846,9 @@
   "26.1.2": {
     "datapack": 101.1,
     "resourcepack": 84
+  },
+  "26.2-snapshot-2": {
+    "datapack": 101.2,
+    "resourcepack": 85
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-snapshot-2.