### PR TITLE
fix(pack-format): update pack-format map for 26.2-snapshot-3

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1850,5 +1850,9 @@
   "26.2-snapshot-2": {
     "datapack": 101.2,
     "resourcepack": 85
+  },
+  "26.2-snapshot-3": {
+    "datapack": 102,
+    "resourcepack": 86
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-snapshot-3.