### PR TITLE
fix(pack-format): update pack-format map for 26.2-snapshot-4

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1854,5 +1854,9 @@
   "26.2-snapshot-3": {
     "datapack": 102,
     "resourcepack": 86
+  },
+  "26.2-snapshot-4": {
+    "datapack": 103,
+    "resourcepack": 86.1
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-snapshot-4.