### PR TITLE
fix(pack-format): update pack-format map for 26.2-snapshot-5

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1858,5 +1858,9 @@
   "26.2-snapshot-4": {
     "datapack": 103,
     "resourcepack": 86.1
+  },
+  "26.2-snapshot-5": {
+    "datapack": 104,
+    "resourcepack": 86.2
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-snapshot-5.