### PR TITLE
fix(pack-format): update pack-format map for 26.2-snapshot-6

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1862,5 +1862,9 @@
   "26.2-snapshot-5": {
     "datapack": 104,
     "resourcepack": 86.2
+  },
+  "26.2-snapshot-6": {
+    "datapack": 105,
+    "resourcepack": 86.2
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-snapshot-6.