### PR TITLE
fix(pack-format): update pack-format map for 26.2-snapshot-7

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1866,5 +1866,9 @@
   "26.2-snapshot-6": {
     "datapack": 105,
     "resourcepack": 86.2
+  },
+  "26.2-snapshot-7": {
+    "datapack": 105.1,
+    "resourcepack": 87
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-snapshot-7.