### PR TITLE
fix(pack-format): update pack-format map for 26.2-snapshot-8

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1870,5 +1870,9 @@
   "26.2-snapshot-7": {
     "datapack": 105.1,
     "resourcepack": 87
+  },
+  "26.2-snapshot-8": {
+    "datapack": 106,
+    "resourcepack": 87
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-snapshot-8.