### PR TITLE
fix(pack-format): update pack-format map for 26.2-pre-1

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1874,5 +1874,9 @@
   "26.2-snapshot-8": {
     "datapack": 106,
     "resourcepack": 87
+  },
+  "26.2-pre-1": {
+    "datapack": 106.1,
+    "resourcepack": 88
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-pre-1.