### PR TITLE
fix(pack-format): update pack-format map for 26.2-pre-2

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1878,5 +1878,9 @@
   "26.2-pre-1": {
     "datapack": 106.1,
     "resourcepack": 88
+  },
+  "26.2-pre-2": {
+    "datapack": 107,
+    "resourcepack": 88
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-pre-2.