### PR TITLE
fix(pack-format): update pack-format map for 26.2-pre-4

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1886,5 +1886,9 @@
   "26.2-pre-3": {
     "datapack": 107,
     "resourcepack": 88
+  },
+  "26.2-pre-4": {
+    "datapack": 107.1,
+    "resourcepack": 88
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-pre-4.