### PR TITLE
fix(pack-format): update pack-format map for 26.2-pre-6

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1894,5 +1894,9 @@
   "26.2-pre-5": {
     "datapack": 107.1,
     "resourcepack": 88
+  },
+  "26.2-pre-6": {
+    "datapack": 107.1,
+    "resourcepack": 88
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-pre-6.