### PR TITLE
fix(pack-format): update pack-format map for 26.2-rc-2

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1902,5 +1902,9 @@
   "26.2-rc-1": {
     "datapack": 107.1,
     "resourcepack": 88
+  },
+  "26.2-rc-2": {
+    "datapack": 107.1,
+    "resourcepack": 88
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.2-rc-2.