### PR TITLE
fix(pack-format): update pack-format map for 26.3-snapshot-1

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1910,5 +1910,9 @@
   "26.2": {
     "datapack": 107.1,
     "resourcepack": 88
+  },
+  "26.3-snapshot-1": {
+    "datapack": 108,
+    "resourcepack": 89
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.3-snapshot-1.