### PR TITLE
fix(pack-format): update pack-format map for 26.3-snapshot-2

### DIFF
--- a/src/main/resources/pack_versions.json
+++ b/src/main/resources/pack_versions.json
@@ -1914,5 +1914,9 @@
   "26.3-snapshot-1": {
     "datapack": 108,
     "resourcepack": 89
+  },
+  "26.3-snapshot-2": {
+    "datapack": 109,
+    "resourcepack": 90
   }
 }


### PR DESCRIPTION
Automated update of **src/main/resources/pack_versions.json**.

Versions added: 26.3-snapshot-2.