### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,7 +46,7 @@ jobs:
             path: ./docs/build
 
     deploy_pages:
-      runs-on: ubuntu-latest
+      runs-on: self-hosted
       needs: build
       environment:
         name: github-pages


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.