### PR TITLE
chore: enforce minimum dependency age

### DIFF
--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   core-js: true
+minimumReleaseAge: 10080
 onlyBuiltDependencies:
   - core-js
   - core-js-pure


### PR DESCRIPTION
## Summary
- add `minimumReleaseAge: 10080` to the documentation pnpm workspace metadata
- require dependencies to be at least seven days old before installation

## Verification
- inspected the staged diff and confirmed only `docs/pnpm-workspace.yaml` changed
- ran `git diff --staged --check`
- did not run pnpm, scripts, tests, linters, formatters, builds, or validators as required for this metadata-only change